### PR TITLE
Explicitly disable formatOnSave in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "deepscan.enable": true,
   "mochaExplorer.files": "test/**/*.ts",
-  "mochaExplorer.require": "ts-node/register"
+  "mochaExplorer.require": "ts-node/register",
+  "editor.formatOnSave": false
 }


### PR DESCRIPTION
It seems that formatOnSave tries to obey the prettier line width of 110, which wraps a whole bunch of lines that haven't been wrapped in the past and violate other prettier rules about code layout, this seems to fix it.