### PR TITLE
fix: search query regex

### DIFF
--- a/src/search/search.ts
+++ b/src/search/search.ts
@@ -44,7 +44,7 @@ const defaultOptions: SearchOptions = {
   marketRegion: 'en-US'
 };
 
-const SEARCH_REGEX = /DDG\.pageLayout\.load\('d',(\[.+\])\);DDG\.duckbar\.load\('images'/;
+const SEARCH_REGEX = /DDG\.pageLayout\.load\('d',(\[.+\])\);DDG\.duckbar\.load\('/;
 const IMAGES_REGEX = /;DDG\.duckbar\.load\('images', ({"ads":.+"vqd":{".+":"\d-\d+-\d+"}})\);DDG\.duckbar\.load\('news/;
 const NEWS_REGEX = /;DDG\.duckbar\.load\('news', ({"ads":.+"vqd":{".+":"\d-\d+-\d+"}})\);DDG\.duckbar\.load\('videos/;
 const VIDEOS_REGEX = /;DDG\.duckbar\.load\('videos', ({"ads":.+"vqd":{".+":"\d-\d+-\d+"}})\);DDG\.duckbar\.loadModule\('related_searches/;


### PR DESCRIPTION
Fixes the following error `TypeError: Cannot read properties of null (reading '1')` which happens when the response is valid but keys are not in an expected order.

Query: `News in the world`

Closes: https://github.com/Snazzah/duck-duck-scrape/issues/143