### PR TITLE
add line drawing filter

### DIFF
--- a/src/search/images.ts
+++ b/src/search/images.ts
@@ -29,7 +29,9 @@ export enum ImageType {
   /** Animated GIFs. */
   GIF = 'gif',
   /** Transparent photos. */
-  TRANSPARENT = 'transparent'
+  TRANSPARENT = 'transparent',
+  /** Line drawings. */
+  LINE_DRAWING = 'line'
 }
 
 /** The types of image layouts. */


### PR DESCRIPTION
![e1ec5b09587df772dd88a40e1fd6c517](https://github.com/user-attachments/assets/c16846bf-8f0b-40b2-99f6-278798c1e1b4)

Adds the option to set image type to LINE_DRAWING (as as of now it throws an error)